### PR TITLE
Adjust Gold Diff to use Normal Distribution rather than Linear

### DIFF
--- a/elo_adjuster.py
+++ b/elo_adjuster.py
@@ -1,7 +1,7 @@
 import math
+from statistics import NormalDist
 
 from player import Player
-
 
 LANE_K: int = 16
 GAME_K: int = 10
@@ -21,7 +21,8 @@ def new_elo(player: Player, index: int, enemies: list[Player], gold_diff: int, g
     elif gold_diff <= -1000:
         gold_diff = 0
     else:
-        gold_diff = gold_diff/2000 + 0.5
+        # gold diff is normalized
+        gold_diff = NormalDist(sigma=333.33).cdf(gold_diff)
     # calculate elo adjustment based on lane outcome
     lane_elo = LANE_K/math.floor((player.games_played + 1) / PLAY_FACTOR + 1) * (
         gold_diff - probability(player.elo, enemies[index].elo))

--- a/player_info.json
+++ b/player_info.json
@@ -4,71 +4,71 @@
       "name": "test_1",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 1,
-      "elo": 428
+      "games_played": 3,
+      "elo": 451
     },
     {
       "name": "test_2",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 1,
-      "elo": 428
+      "games_played": 3,
+      "elo": 455
     },
     {
       "name": "test_3",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 1,
-      "elo": 428
+      "games_played": 3,
+      "elo": 476
     },
     {
       "name": "test_4",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 1,
-      "elo": 428
+      "games_played": 3,
+      "elo": 397
     },
     {
       "name": "test_5",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 1,
-      "elo": 428
+      "games_played": 3,
+      "elo": 395
     },
     {
       "name": "test_6",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 1,
-      "elo": 372
+      "games_played": 3,
+      "elo": 428
     },
     {
       "name": "test_7",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 1,
-      "elo": 372
+      "games_played": 3,
+      "elo": 428
     },
     {
       "name": "test_8",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 1,
-      "elo": 372
+      "games_played": 3,
+      "elo": 326
     },
     {
       "name": "test_9",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 1,
-      "elo": 372
+      "games_played": 3,
+      "elo": 324
     },
     {
       "name": "test_10",
       "rank": "LOW_SILVER",
       "roles": ["FILL"],
-      "games_played": 0,
-      "elo": 400
+      "games_played": 2,
+      "elo": 348
     },
     {
       "name": "adib",
@@ -164,7 +164,7 @@
     {
       "name": "alex",
       "rank": "LOW_EMERALD",
-      "roles": ["BOT", "JG"],
+      "roles": ["FILL"],
       "games_played": 0,
       "elo": 1000
     },

--- a/post_game_adjustment.py
+++ b/post_game_adjustment.py
@@ -39,8 +39,12 @@ with open("game_data.json", "r+") as file:
 for i in range(5):
     new_elo_1.append(
         new_elo(team_1[i], i, team_2[:], results[i + 1], results[0] % 2))
+    print(team_1[i].name + ": " + str(team_1[i].elo) +
+          " -> " + str(new_elo_1[i]))
     new_elo_2.append(
         new_elo(team_2[i], i, team_1[:], -1 * results[i + 1], results[0] - 1))
+    print(team_2[i].name + ": " + str(team_2[i].elo) +
+          " -> " + str(new_elo_2[i]))
 
 # update the players
 for i in range(5):


### PR DESCRIPTION
- Gold diff is using a normal distribution (This is because it is compared to the probability to win so it makes more sense to use probability [area is 1] rather than a linear equation)
- Prints old to new elo after game (Just so everyone doesn't yell at me after the game)
- alex to fill (Patch 0.2)